### PR TITLE
Add static seek mode and seek scale options

### DIFF
--- a/touch-gestures.lua
+++ b/touch-gestures.lua
@@ -102,7 +102,7 @@ local function drag_seek(dx)
     if opts.proportional_seek == 'yes' then
         time = math.max(drag_total / ds_w * ds_dur * opts.seek_scale + ds_time, 0)
     else
-        time = math.max(drag_total * opts.seek_scale + ds_time, 0)
+        time = math.max(drag_total * opts.seek_scale / scale + ds_time, 0)
     end
 
     if ds_w / ds_dur < 10 then

--- a/touch-gestures.lua
+++ b/touch-gestures.lua
@@ -9,6 +9,8 @@ local msg = require('mp.msg')
 
 local opts = {
     horizontal_drag = 'playlist',
+    proportional_seek = 'yes',
+    seek_scale = 1,
 }
 options.read_options(opts, 'touch-gestures')
 
@@ -96,7 +98,13 @@ seek_timer:kill()
 local function drag_seek(dx)
     if not ds_dur then return end
     drag_total = drag_total + dx
-    time = math.max(drag_total / ds_w * ds_dur + ds_time, 0)
+
+    if opts.proportional_seek == 'yes' then
+        time = math.max(drag_total / ds_w * ds_dur * opts.seek_scale + ds_time, 0)
+    else
+        time = math.max(drag_total * opts.seek_scale + ds_time, 0)
+    end
+
     if ds_w / ds_dur < 10 then
         -- Perform a fast seek while moving around and an exact seek afterwards
         seek(true)


### PR DESCRIPTION
This pull request adds support for a new seek mode, that always seeks the same amount for a given length of swipe, independently of length of opened media. It still depends on screen pixel density, though...

In the new seek mode a full screen width swipe on an 1300 pixel wide screen seeks ~22 minutes by default (each pixel 1 second).

I have tried preserving the original defaults, so this does not replace the default seek mode, and the default seek mode should seek the same amount as before, except if the user configures it otherwise.